### PR TITLE
add raft label filtering capabilities at the RPC check layer

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -15,6 +15,8 @@ type RPCHeader struct {
 	ID []byte
 	// Addr is the ServerAddr of the node sending the RPC Request or Response
 	Addr []byte
+	// Label is the label the sender is configured with
+	Label string
 }
 
 // WithRPCHeader is an interface that exposes the RPC header.

--- a/config.go
+++ b/config.go
@@ -235,6 +235,9 @@ type Config struct {
 	// PreVoteDisabled deactivate the pre-vote feature when set to true
 	PreVoteDisabled bool
 
+	Label          string
+	SkipLabelCheck bool
+
 	// skipStartup allows NewRaft() to bypass all background work goroutines
 	skipStartup bool
 }


### PR DESCRIPTION
Add 2 new config elements
Label
SkipLabelCheck

The idea behind it is to have a mechanism to label RPC being sent between two raft peers and act on that label to filter out RPC. 
Added related tests